### PR TITLE
Build form pilot extension and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# OCR_test
+# FormPilot
+
+FormPilot is an open-source, privacy-first tool that extracts structured data from PDFs and seamlessly autofills web forms in your browser.
+
+## Monorepo Layout
+
+```
+/extension   – Chrome extension (MV3) built with React + Vite
+/backend     – FastAPI service for local PDF parsing & optional cloud providers
+/shared      – Re-usable shared types & utilities (TypeScript)
+```
+
+## Quick Start (Development)
+
+### Prerequisites
+
+* Node.js ≥ 18.x
+* Python ≥ 3.11
+* pnpm (preferred) or npm/yarn
+
+### Install dependencies
+
+```bash
+pnpm install       # installs root + extension workspace deps
+python -m venv .venv && source .venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+### Run everything (hot-reload)
+
+```bash
+pnpm dev           # concurrently launches Vite (extension) & uvicorn (backend)
+```
+
+### Building production bundles
+
+```bash
+pnpm build         # builds extension bundle
+```
+
+## License
+
+MIT © 2023-present FormPilot contributors

--- a/shared/Field.ts
+++ b/shared/Field.ts
@@ -1,0 +1,34 @@
+export type BBox = [number, number, number, number]; // x0, y0, x1, y1 (PDF coordinate space)
+
+export interface Candidate {
+  /** Extracted value */
+  value: string;
+  /** Model-estimated confidence (0-1) */
+  confidence: number;
+  /** Bounding box on the PDF page */
+  bbox: BBox;
+  /** Optional raw source text (for scanned docs) */
+  sourceText?: string;
+  /** 1-indexed page number */
+  page: number;
+}
+
+export interface ValidationResult {
+  /** Name of the validation rule e.g. "regex:ssn" */
+  rule: string;
+  /** Whether the value passed validation */
+  passed: boolean;
+  /** Optional message if validation failed */
+  message?: string;
+}
+
+export interface Field {
+  /** Canonical field identifier (snake_case) */
+  canonical: string;
+  /** Candidate extractions sorted by confidence */
+  candidates: Candidate[];
+  /** Chosen candidate (user-approved) */
+  chosen?: Candidate;
+  /** Validation results */
+  validations: ValidationResult[];
+}


### PR DESCRIPTION
Initialize monorepo structure and define core shared TypeScript types for FormPilot.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fee3cd2-b913-4852-bc41-45db11d93ec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fee3cd2-b913-4852-bc41-45db11d93ec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

